### PR TITLE
Fix cdn links to work with http or https

### DIFF
--- a/app/application/controllers/home.php
+++ b/app/application/controllers/home.php
@@ -7,12 +7,10 @@ class Home extends CI_Controller {
 		parent::__construct();
 		$this->load->model('link','',TRUE);
 	}
-	
+
 	function search()
 	{
-		// Set CORS headers so AJAX requests work on my.harvard.edu
-		$this->output->set_header("Access-Control-Allow-Origin: http://my.harvard.edu https://my.harvard.edu");
-		$this->output->set_header("Access-Control-Allow-Methods: GET, POST");
+		$this->_setCORSHeaders();
 
 		# Get Links
 		$categoriesPOST = $this->input->post('categories');
@@ -80,5 +78,20 @@ class Home extends CI_Controller {
 		$data['test'] = "test";
 		$this->load->view('home_view', $data);
 	}
+
+	// Set cross-origin resource sharing headers for harvard.edu domains
+	function _setCORSHeaders() 
+	{
+		$origin = $_SERVER['HTTP_ORIGIN'];
+		$domain = '.harvard.edu';
+		$allow_origin = (substr($origin, -strlen($domain)) === $domain);
+
+		if($allow_origin) {
+			// Set CORS headers so AJAX requests work on my.harvard.edu
+			$this->output->set_header("Access-Control-Allow-Origin: $origin");
+			$this->output->set_header("Access-Control-Allow-Methods: GET, POST");
+		}
+	}
+	
 }
 ?>

--- a/app/application/controllers/home.php
+++ b/app/application/controllers/home.php
@@ -10,6 +10,9 @@ class Home extends CI_Controller {
 	
 	function search()
 	{
+		// Set CORS headers so AJAX requests work on my.harvard.edu
+		$this->output->set_header("Access-Control-Allow-Origin: http://my.harvard.edu https://my.harvard.edu");
+		$this->output->set_header("Access-Control-Allow-Methods: GET, POST");
 
 		# Get Links
 		$categoriesPOST = $this->input->post('categories');

--- a/app/application/controllers/home.php
+++ b/app/application/controllers/home.php
@@ -10,7 +10,7 @@ class Home extends CI_Controller {
 
 	function search()
 	{
-		$this->_setCORSHeaders();
+		$callback = $this->input->get('callback');
 
 		# Get Links
 		$categoriesPOST = $this->input->post('categories');
@@ -69,8 +69,15 @@ class Home extends CI_Controller {
 		}
 		array_multisort($score, SORT_DESC, $linksArray);
 		
-		# Return Links
-		echo json_encode($linksArray);
+		# Return Links encoded as JSON
+		$jsondata = json_encode($linksArray);
+		if($callback) {
+			$result = $callback."($jsondata)";
+		} else {
+			$result = $jsondata;
+		}
+
+		echo $result;
 	}	
 
 	function index()
@@ -78,20 +85,5 @@ class Home extends CI_Controller {
 		$data['test'] = "test";
 		$this->load->view('home_view', $data);
 	}
-
-	// Set cross-origin resource sharing headers for harvard.edu domains
-	function _setCORSHeaders() 
-	{
-		$origin = $_SERVER['HTTP_ORIGIN'];
-		$domain = '.harvard.edu';
-		$allow_origin = (substr($origin, -strlen($domain)) === $domain);
-
-		if($allow_origin) {
-			// Set CORS headers so AJAX requests work on my.harvard.edu
-			$this->output->set_header("Access-Control-Allow-Origin: $origin");
-			$this->output->set_header("Access-Control-Allow-Methods: GET, POST");
-		}
-	}
-	
 }
 ?>

--- a/app/application/views/home_view.php
+++ b/app/application/views/home_view.php
@@ -223,33 +223,33 @@
 
 		$.ajax({
 			type: "POST",
-	        url: AJAX_SEARCH_URL,
-	        data: data,
-			jsonp: "callback",
-			dataType: "jsonp",
-	        complete: function (xhr, status) {
-	        	logdata(xhr);
-                showhelp(categories.length==0?true:false);
-                resetresults();
-		    	if (status === 'error' || xhr.statusText != "OK") {
-			        alert("Could not complete search.");
-			    } else {
-			        // Success
-			        if (xhr.responseText == "") {
-			        	$("#textBox").val("");
-			        	$("#text_search").hide();
+			url: AJAX_SEARCH_URL,
+			data: data,
+			//jsonp: "callback",
+			//dataType: "jsonp",
+			complete: function (xhr, status) {
+				logdata(xhr);
+				showhelp(categories.length==0?true:false);
+				resetresults();
+				if (status === 'error' || xhr.statusText != "OK") {
+					alert("Could not complete search.");
+				} else {
+					if (xhr.responseText == "") {
+						$("#textBox").val("");
+						$("#text_search").hide();
 						if(has_missing_subcategories) {
 							emptycategoryresults();
 						} else {
 							emptyresults()
 						}
-			        } else {
+					} else {
 						$("#text_search").show();
-						jsonLinkData = xhr.responseJSON;
-                        addresults(jsonLinkData);
-                    }
-			    }
-                showloadmask(false);
+							//jsonLinkData = xhr.responseJSON;
+							jsonLinkData = JSON.parse(xhr.responseText);
+							addresults(jsonLinkData);
+					}
+				}
+				showloadmask(false);
 			}
 		});
 	}

--- a/app/application/views/home_view.php
+++ b/app/application/views/home_view.php
@@ -4,11 +4,10 @@
 
 <head>
 	<title>Search for Harvard's Online Resources</title>
-	<link href='http://fonts.googleapis.com/css?family=Arimo' rel='stylesheet' type='text/css'>
+	<link href='//fonts.googleapis.com/css?family=Arimo' rel='stylesheet' type='text/css'>
 	<link rel="stylesheet" type="text/css" href="<?php echo asset_url() . 'css/style.css';?>">
 	<!-- jQuery CDN  -->
-	<script src="http://code.jquery.com/jquery-1.10.1.min.js"></script>
-	<script src="http://code.jquery.com/jquery-migrate-1.2.1.min.js"></script>
+	<script src="//ajax.googleapis.com/ajax/libs/jquery/1.11.1/jquery.min.js"></script>
 	
 	<!-- BootStrap CDN -->
 	<!-- Latest compiled and minified CSS -->

--- a/app/application/views/home_view.php
+++ b/app/application/views/home_view.php
@@ -225,6 +225,8 @@
 			type: "POST",
 	        url: AJAX_SEARCH_URL,
 	        data: data,
+			jsonp: "callback",
+			dataType: "jsonp",
 	        complete: function (xhr, status) {
 	        	logdata(xhr);
                 showhelp(categories.length==0?true:false);
@@ -243,7 +245,7 @@
 						}
 			        } else {
 						$("#text_search").show();
-						jsonLinkData = JSON.parse(xhr.responseText);
+						jsonLinkData = xhr.responseJSON;
                         addresults(jsonLinkData);
                     }
 			    }


### PR DESCRIPTION
This PR fixes an issue where the page does not display correctly when loaded via HTTPS. The CDN links have been changed to use relative protocol URLs (i.e. `//` instead of `http://` or `https://`).

In addition, this PR bumps the jQuery version to the latest stable 1.x version and removes the reference to the migration plugin, which should not be needed. 
